### PR TITLE
Use environment proxy settings when making requests

### DIFF
--- a/mturk_crowd_beta_client/__init__.py
+++ b/mturk_crowd_beta_client/__init__.py
@@ -105,7 +105,9 @@ class MTurkCrowdClient(object):
             request.url,
             json.dumps(dict(request.headers)),
             request.body))
-        response = Session().send(request, timeout=_TIMEOUT_SECONDS)
+        session = Session()
+        settings = session.merge_environment_settings(request.url, {}, None, None, None)
+        response = session.send(request, timeout=_TIMEOUT_SECONDS, **settings)
         return response
 
     def _build_aws_sigv4_headers(self, method, uri_path, body):


### PR DESCRIPTION
When using the prepared request flow, [environment settings need to be explicitly folded in](http://docs.python-requests.org/en/master/user/advanced/#prepared-requests). Otherwise things like HTTP_PROXY environment variables will be ignored, and users behind corporate firewalls will get a `ConnectionError` when they make a request.

Incidentally, this is a far friendlier API than the default mturk one. Great job! 